### PR TITLE
Second demo program with more options, graceful error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,13 @@ set(HDMARKER_LIBRARY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/${CMAKE_SHARED_LIBRARY_PR
 add_executable(marker_gen src/bin/marker_gen.cpp)
 target_link_libraries(marker_gen hdmarker)
 
+find_package(GTest REQUIRED)
+add_executable(tests src/tests.cpp)
+target_link_libraries(tests
+  hdmarker
+  ${GTEST_BOTH_LIBRARIES}
+  )
+
 add_dependencies(hdmarker hdmarker-header-export)
 set(CONF_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/include)
 export(TARGETS hdmarker FILE ${hdmarker_BINARY_DIR}/hdmarkerTargets.cmake)
@@ -91,7 +98,11 @@ add_subdirectory(demo/)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hdmarker.pc.in ${CMAKE_CURRENT_BINARY_DIR}/hdmarker.pc @ONLY)
 message("Path: " ${CMAKE_INSTALL_DATAROOTDIR})
 install(FILES ${CMAKE_BINARY_DIR}/hdmarker.pc DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pkgconfig")
+install(FILES ${CMAKE_BINARY_DIR}/hdmarker.pc DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pkgconfig")
 
+install (FILES src/lib/gridstore.hpp src/lib/hdmarker.hpp src/lib/loess.hpp src/lib/subpattern.hpp src/lib/timebench.hpp DESTINATION ${CMAKE_INSTALL_PREFIX}/include/hdmarker)
+
+install (TARGETS hdmarker DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
 
 

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -5,3 +5,23 @@ set_property(TARGET extractMarker PROPERTY CXX_STANDARD 11)
 add_executable(hdmarker-tool demo2.cpp)
 target_link_libraries(hdmarker-tool hdmarker)
 set_property(TARGET hdmarker-tool PROPERTY CXX_STANDARD 11)
+
+find_package(Boost COMPONENTS system filesystem iostreams REQUIRED)
+
+
+add_library(hdmarker-simple-calib-lib simplecalib.cpp)
+target_link_libraries(hdmarker-simple-calib-lib
+  hdmarker
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
+  )
+set_property(TARGET hdmarker-simple-calib-lib PROPERTY CXX_STANDARD 11)
+
+add_executable(hdmarker-simple-calib simple-calib.cpp)
+target_link_libraries(hdmarker-simple-calib
+  hdmarker
+  ${Boost_FILESYSTEM_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
+  hdmarker-simple-calib-lib
+  )
+set_property(TARGET hdmarker-simple-calib PROPERTY CXX_STANDARD 11)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(extractMarker demo.cpp)
 target_link_libraries(extractMarker hdmarker)
 set_property(TARGET extractMarker PROPERTY CXX_STANDARD 11)
+
+add_executable(hdmarker-tool demo2.cpp)
+target_link_libraries(hdmarker-tool hdmarker)
+set_property(TARGET hdmarker-tool PROPERTY CXX_STANDARD 11)

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -281,7 +281,8 @@ int main(int argc, char* argv[])
     putText(paint, buf, c.p, FONT_HERSHEY_PLAIN, 0.5, Scalar(0,0,0,0), 2, CV_AA);
     putText(paint, buf, c.p, FONT_HERSHEY_PLAIN, 0.5, Scalar(255,255,255,0), 1, CV_AA);
   }
-  
+  imwrite(argv[2], paint);
+
 //   
   Mat gray;
   if (img.channels() != 1)
@@ -296,7 +297,13 @@ int main(int argc, char* argv[])
   vector<Corner> corners_f2;
   check_calibration(corners_sub, img.size().width, img.size().height, img, corners_f2);
   
-  imwrite(argv[2], paint);
+  if (argc > 3) {
+    cv::Mat paint2 = paint.clone();
+    for (hdmarker::Corner const& c : corners_f2) {
+      circle(paint2, c.p, 3, Scalar(0,0,255,0), -1, LINE_AA);
+    }
+    imwrite(argv[3], paint2);
+  }
 
 //  microbench_measure_output("app finish");
   return EXIT_SUCCESS;

--- a/demo/demo2.cpp
+++ b/demo/demo2.cpp
@@ -1,0 +1,356 @@
+/**
+* @file demo.cpp
+* @brief demo application of hdmarker
+*
+* @author Hendrik Schilling (implementation)
+* @author Maximilian Diebold (documentation)
+* @date 01/15/2018
+*/
+
+#include <stdio.h>
+#include "hdmarker.hpp"
+//#include "timebench.hpp"
+#include "subpattern.hpp"
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+
+#include <iostream>
+#include <unordered_map>
+
+#include <tclap/CmdLine.h>
+
+using namespace std;
+using namespace cv;
+using namespace hdmarker;
+
+const int grid_width = 1;
+const int grid_height = 1;
+
+const bool use_rgb = false;
+
+Point3f add_zero_z(Point2f p2)
+{
+    Point3f p = {p2.x, p2.y, 0.0};
+
+    return p;
+}
+
+Point2f grid_to_world(Corner &c, int grid_w)
+{
+    Point2f p;
+    int px, py;
+
+    px = c.page % grid_w;
+    py = c.page / grid_w;
+    px*=32;
+    py*=32;
+
+    p.x = c.id.x+px;
+    p.y = c.id.y+py;
+
+    return p;
+}
+
+bool calib_savepoints(vector<vector<Point2f> > all_img_points[4], vector<vector<Point3f> > &all_world_points, vector<Corner> &corners, int hpages, int vpages, vector<Corner> &corners_filtered)
+{
+    if (!corners.size()) return false;
+
+    vector<Point2f> plane_points;
+    vector<Point2f> img_points[4];
+    vector<Point3f> world_points;
+    vector<Point2f> img_points_check[4];
+    vector<Point2f> world_points_check;
+    vector<int> pos;
+    vector <uchar> inliers;
+
+    for(uint i=0;i<corners.size();i++) {
+        int px, py;
+        if (corners[i].page > hpages*vpages)
+            continue;
+        /*if (corners[i].page != 0)
+      continue;*/
+        px = corners[i].page % hpages;
+        py = corners[i].page / hpages;
+        px*=32;
+        py*=32;
+        img_points_check[0].push_back(corners[i].p);
+        pos.push_back(i);
+        for(int c=1;c<4;c++)
+            if (all_img_points[c].size())
+                img_points_check[c].push_back(corners[i].pc[c-1]);
+        world_points_check.push_back(grid_to_world(corners[i], hpages));
+    }
+
+    inliers.resize(world_points_check.size());
+    Mat hom = findHomography(world_points_check, img_points_check[0], CV_RANSAC, 100, inliers);
+
+    vector<Point2f> proj;
+    perspectiveTransform(world_points_check, proj, hom);
+
+    double rms = 0.0;
+    for(uint i=0;i<inliers.size();i++) {
+        if (!inliers[i])
+            continue;
+        rms += norm(img_points_check[0][i]-proj[i])*norm(img_points_check[0][i]-proj[i]);
+        corners_filtered.push_back(corners[pos[i]]);
+        img_points[0].push_back((img_points_check[0])[i]);
+        for(int c=1;c<4;c++)
+            if (all_img_points[c].size())
+                img_points[c].push_back((img_points_check[c])[i]);
+        world_points.push_back(add_zero_z(world_points_check[i]));
+    }
+    printf("homography rms: %f\n", sqrt(rms/inliers.size()));
+
+    printf("findHomography: %lu inliers of %lu calibration points (%.2f%%)\n", img_points[0].size(),img_points_check[0].size(),img_points[0].size()*100.0/img_points_check[0].size());
+
+    (all_img_points[0])[0] = img_points[0];
+    for(int c=1;c<4;c++)
+        if (all_img_points[c].size())
+            (all_img_points[c])[0] = img_points[c];
+    all_world_points[0] = world_points;
+
+    return true;
+}
+
+void calibrate_channel(vector<vector<Point2f> > &img_points, vector<vector<Point3f> > &world_points, int w, int h, Mat &img)
+{
+    vector<Mat> rvecs, tvecs;
+    Mat cameraMatrix(3,3,cv::DataType<double>::type);
+    Mat distCoeffs;
+    double rms;
+    vector<Point2f> projected;
+    Mat paint;
+
+    distCoeffs = Mat::zeros(1, 8, CV_64F);
+    //use CV_CALIB_ZERO_TANGENT_DIST or we get problems when using single image!
+    rms = calibrateCamera(world_points, img_points, Size(w, h), cameraMatrix, distCoeffs, rvecs, tvecs, CV_CALIB_ZERO_TANGENT_DIST | CV_CALIB_RATIONAL_MODEL);
+    printf("rms %f with full distortion correction\n", rms);
+
+    cout << distCoeffs << endl;
+
+    projectPoints(world_points[0], rvecs[0], tvecs[0], cameraMatrix, distCoeffs, projected);
+    if (img.channels() == 1)
+        cvtColor(img, paint, CV_GRAY2BGR);
+    else
+        paint = img.clone();
+    //resize(paint, paint, Size(Point2i(paint.size())*4), INTER_LINEAR);
+    for(uint i=0;i<projected.size();i++) {
+        /*Point2f c = img_points[0][i]*4.0+Point2f(2,2);
+    Point2f d = projected[i] - img_points[0][i];
+    line(paint, c-Point2f(2,0), c+Point2f(2,0), Scalar(0,255,0));
+    line(paint, c-Point2f(0,2), c+Point2f(0,2), Scalar(0,255,0));
+    line(paint, c, c+10*d, Scalar(0,0,255));*/
+
+        Point2f c = img_points[0][i];
+        Point2f d = img_points[0][i]-projected[i];
+        line(paint, c-Point2f(2,0), c+Point2f(2,0), Scalar(0,255,0));
+        line(paint, c-Point2f(0,2), c+Point2f(0,2), Scalar(0,255,0));
+        line(paint, c, c+10*d, Scalar(0,0,255));
+    }
+
+    imwrite("off_hdm.jpg", paint);
+}
+
+void check_calibration(vector<Corner> &corners, int w, int h, Mat &img, vector<Corner> &corners_filtered)
+{
+    vector<Mat> rvecs, tvecs;
+    Mat cameraMatrix(3,3,cv::DataType<double>::type);
+    Mat distCoeffs;
+    vector<Point2f> projected;
+    Mat paint;
+
+    vector<vector<Point3f>> world_points(1);
+    vector<vector<Point2f>> img_points[4];
+
+    img_points[0].resize(1);
+    if (use_rgb)
+        for(int c=1;c<4;c++)
+            img_points[c].resize(1);
+
+    printf("corners: %lu\n", corners.size());
+
+    if (!calib_savepoints(img_points, world_points, corners, grid_width, grid_height, corners_filtered)) {
+        return;
+    }
+
+    calibrate_channel(img_points[0], world_points, w, h, img);
+    if (use_rgb)
+        for(int c=1;c<4;c++)
+            calibrate_channel(img_points[c], world_points, w, h, img);
+
+
+    /*cornerSubPix(img, img_points[0], Size(4,4), Size(-1, -1), TermCriteria(TermCriteria::COUNT | TermCriteria::EPS, 100, 0.001));
+
+  distCoeffs = Mat::zeros(1, 8, CV_64F);
+  rms = calibrateCamera(world_points, img_points, Size(w, h), cameraMatrix, distCoeffs, rvecs, tvecs, CV_CALIB_RATIONAL_MODEL);
+  printf("rms %f with full distortion correction, opencv cornerSubPix\n", rms);
+
+  projectPoints(world_points[0], rvecs[0], tvecs[0], cameraMatrix, distCoeffs, projected);
+  cvtColor(img, paint, CV_GRAY2BGR);
+  for(int i=0;i<projected.size();i++) {
+    Point2f d = projected[i] - img_points[0][i];
+    line(paint, img_points[0][i], img_points[0][i]+100*d, Scalar(0,0,255));
+  }
+  imwrite("off_ocv.png", paint);*/
+}
+
+void corrupt(Mat &img)
+{
+    GaussianBlur(img, img, Size(9,9), 0);
+    Mat noise = Mat(img.size(), CV_32F);
+    img. convertTo(img, CV_32F);
+    randn(noise, 0, 3.0);
+    img += noise;
+    img.convertTo(img, CV_8U);
+    cvtColor(img, img, COLOR_BayerBG2BGR_VNG);
+    cvtColor(img, img, CV_BGR2GRAY);
+}
+
+
+
+/**
+ * ## HDmarker demo {#Demo_hdmarker}
+ *
+ * @name    Example API Actions
+ * @brief   Example of how to use the marker extraction.
+ *
+ * This API provides certain actions as an example of the usage.
+ *
+ * @param [in] calibration_image  Provides image of marker.
+ * @param [in] result_image  Contains detected markers.
+ *
+ *
+ * Example Usage:
+ * @code
+ *    extractMarker extractDemo.png Result.png; // Extracts marker with refinement and saves an image of all found markers
+ * @endcode
+ */
+int main(int argc, char* argv[])
+{
+
+    std::string input_file, output_file;
+    int recursion_depth = -1;
+    float effort = 0.5;
+    bool demosaic = false;
+    try {
+        TCLAP::CmdLine cmd("hdmarker extraction tool", ' ', "0.1");
+
+        TCLAP::ValueArg<std::string> input_img_arg("i", "input", "Input image, should contain markers",
+                                                   true, "", "string");
+        cmd.add(input_img_arg);
+
+        TCLAP::ValueArg<std::string> output_img_arg("o", "output",
+                                                    "Prefix for output image. The programm will write '-1.png' and '-2.png' with detected markers (1) and sub-markers(2). Default is the input filename.",
+                                                    false, "", "string");
+        cmd.add(output_img_arg);
+
+        TCLAP::ValueArg<int> recursive_depth_arg("r", "recursion",
+                                                 "Recursion depth of the sub-marker detection. Set this to the actual recursion depth of the used target.",
+                                                 false, -1, "int");
+        cmd.add(recursive_depth_arg);
+
+        TCLAP::ValueArg<float> effort_arg("e", "effort",
+                                          "Effort value for the marker detection.",
+                                          false, .5, "float");
+        cmd.add(effort_arg);
+
+        TCLAP::SwitchArg demosaic_arg("d", "demosaic",
+                                      "Use this flag if the input image is a raw image and demosaicing should be used.",
+                                      false);
+
+        cmd.parse(argc, argv);
+
+        input_file = input_img_arg.getValue();
+        output_file = output_img_arg.isSet() ? output_img_arg.getValue() : input_img_arg.getValue();
+        recursion_depth = recursive_depth_arg.getValue();
+        effort = effort_arg.getValue();
+        demosaic = demosaic_arg.getValue();
+
+        std::cout << "Parameters: " << std::endl
+                  << "Input file: " << input_file << std::endl
+                  << "output file: " << output_file << std::endl
+                  << "recursion depth: " << recursion_depth << std::endl
+                  << "effort: " << effort << std::endl
+                  << "demosaic: " << (demosaic ? "true" : "false") << std::endl;
+    }
+    catch (TCLAP::ArgException const & e) {
+        std::cerr << e.what() << std::endl;
+        return 0;
+    }
+    catch (...) {
+        std::cerr << "Unknown exception" << std::endl;
+        return 0;
+    }
+
+
+    //  microbench_init();
+    char buf[64];
+    Mat img, paint;
+    Point2f p1, p2;
+    int x1, y1, x2, y2;
+    vector<Corner> corners;
+    Corner c;
+
+    if (demosaic) {
+        img = cv::imread(input_file, CV_LOAD_IMAGE_GRAYSCALE);
+        cvtColor(img, img, COLOR_BayerBG2BGR);
+        paint = img.clone();
+    }
+    else {
+        img = cv::imread(input_file);
+        paint = img.clone();
+    }
+    std::cout << "Input image size: " << img.size << std::endl;
+
+    //corrupt(img);
+    //imwrite("corrupted.png", img);
+    Marker::init();
+
+    //  microbench_measure_output("app startup");
+
+    //CALLGRIND_START_INSTRUMENTATION;
+    detect(img, corners,use_rgb,0,10, effort, 3);
+    //CALLGRIND_STOP_INSTRUMENTATION;
+
+    //  microbench_init();
+
+    printf("final score %d corners\n", corners.size());
+
+    for(int i=0;i<corners.size();i++) {
+        c = corners[i];
+        //if (c.page != 256) continue;
+        sprintf(buf, "%d/%d", c.id.x, c.id.y);
+        circle(paint, c.p, 1, Scalar(0,0,0,0), 2);
+        circle(paint, c.p, 1, Scalar(0,255,0,0));
+        putText(paint, buf, c.p, FONT_HERSHEY_PLAIN, 0.5, Scalar(0,0,0,0), 2, CV_AA);
+        putText(paint, buf, c.p, FONT_HERSHEY_PLAIN, 0.5, Scalar(255,255,255,0), 1, CV_AA);
+    }
+    imwrite(output_file + "-1.png", paint);
+
+    //
+    Mat gray;
+    if (img.channels() != 1)
+        cvtColor(img, gray, CV_BGR2GRAY);
+    else
+        gray = img;
+
+    if (recursion_depth > 0) {
+        std::cout << "Drawing sub-markers" << std::endl;
+        vector<Corner> corners_sub;
+        double msize = 1.0;
+        refine_recursive(gray, corners, corners_sub, 3, &msize);
+
+        vector<Corner> corners_f2;
+        check_calibration(corners_sub, img.size().width, img.size().height, img, corners_f2);
+
+        cv::Mat paint2 = paint.clone();
+        for (hdmarker::Corner const& c : corners_f2) {
+            circle(paint2, c.p, 3, Scalar(0,0,255,0), -1, LINE_AA);
+        }
+        imwrite(output_file + "-2.png", paint2);
+    }
+
+    //  microbench_measure_output("app finish");
+    return EXIT_SUCCESS;
+}

--- a/demo/simple-calib.cpp
+++ b/demo/simple-calib.cpp
@@ -1,0 +1,423 @@
+/**
+* @file simple-calib.cpp
+* @brief demo calibration application of hdmarker
+*
+* @author Alexander Brock
+* @date 02/20/2019
+*/
+
+#include <stdio.h>
+#include <map>
+#include <iostream>
+#include <unordered_map>
+
+#include "hdmarker.hpp"
+//#include "timebench.hpp"
+#include "subpattern.hpp"
+
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/calib3d/calib3d.hpp>
+
+#include <tclap/CmdLine.h>
+
+#include <boost/filesystem.hpp>
+
+const int grid_width = 1;
+const int grid_height = 1;
+
+const bool use_rgb = false;
+
+using namespace std;
+using namespace hdmarker;
+using namespace cv;
+
+namespace fs = boost::filesystem;
+
+cv::Point3f add_zero_z(cv::Point2f p2)
+{
+    cv::Point3f p = {p2.x, p2.y, 0.0};
+
+    return p;
+}
+
+cv::Point2f grid_to_world(hdmarker::Corner &c, int grid_w)
+{
+    cv::Point2f p;
+    int px, py;
+
+    px = c.page % grid_w;
+    py = c.page / grid_w;
+    px*=32;
+    py*=32;
+
+    p.x = c.id.x+px;
+    p.y = c.id.y+py;
+
+    return p;
+}
+
+bool calib_savepoints(
+        std::vector<std::vector<cv::Point2f> > all_img_points[4],
+        std::vector<std::vector<cv::Point3f> > &all_world_points,
+        std::vector<hdmarker::Corner> &corners,
+        int hpages, int vpages,
+        std::vector<hdmarker::Corner> &corners_filtered)
+{
+    if (!corners.size()) return false;
+
+    std::vector<cv::Point2f> plane_points;
+    std::vector<cv::Point2f> img_points[4];
+    std::vector<cv::Point3f> world_points;
+    std::vector<cv::Point2f> img_points_check[4];
+    std::vector<cv::Point2f> world_points_check;
+    std::vector<int> pos;
+    std::vector <uchar> inliers;
+
+    for(uint i=0;i<corners.size();i++) {
+        int px, py;
+        if (corners[i].page > hpages*vpages)
+            continue;
+        /*if (corners[i].page != 0)
+      continue;*/
+        px = corners[i].page % hpages;
+        py = corners[i].page / hpages;
+        px*=32;
+        py*=32;
+        img_points_check[0].push_back(corners[i].p);
+        pos.push_back(i);
+        for(int c=1;c<4;c++)
+            if (all_img_points[c].size())
+                img_points_check[c].push_back(corners[i].pc[c-1]);
+        world_points_check.push_back(grid_to_world(corners[i], hpages));
+    }
+
+    inliers.resize(world_points_check.size());
+    cv::Mat hom = findHomography(world_points_check, img_points_check[0], CV_RANSAC, 100, inliers);
+
+    std::vector<cv::Point2f> proj;
+    perspectiveTransform(world_points_check, proj, hom);
+
+    double rms = 0.0;
+    for(uint i=0;i<inliers.size();i++) {
+        if (!inliers[i])
+            continue;
+        rms += norm(img_points_check[0][i]-proj[i])*norm(img_points_check[0][i]-proj[i]);
+        corners_filtered.push_back(corners[pos[i]]);
+        img_points[0].push_back((img_points_check[0])[i]);
+        for(int c=1;c<4;c++)
+            if (all_img_points[c].size())
+                img_points[c].push_back((img_points_check[c])[i]);
+        world_points.push_back(add_zero_z(world_points_check[i]));
+    }
+    printf("homography rms: %f\n", sqrt(rms/inliers.size()));
+
+    printf("findHomography: %lu inliers of %lu calibration points (%.2f%%)\n", img_points[0].size(),img_points_check[0].size(),img_points[0].size()*100.0/img_points_check[0].size());
+
+    (all_img_points[0])[0] = img_points[0];
+    for(int c=1;c<4;c++)
+        if (all_img_points[c].size())
+            (all_img_points[c])[0] = img_points[c];
+    all_world_points[0] = world_points;
+
+    return true;
+}
+
+void calibrate_channel(vector<vector<Point2f> > &img_points, vector<vector<Point3f> > &world_points, int w, int h, Mat &img)
+{
+    vector<Mat> rvecs, tvecs;
+    Mat cameraMatrix(3,3,cv::DataType<double>::type);
+    Mat distCoeffs;
+    double rms;
+    vector<Point2f> projected;
+    Mat paint;
+
+    distCoeffs = Mat::zeros(1, 8, CV_64F);
+    //use CV_CALIB_ZERO_TANGENT_DIST or we get problems when using single image!
+    rms = calibrateCamera(world_points, img_points, Size(w, h), cameraMatrix, distCoeffs, rvecs, tvecs, CV_CALIB_ZERO_TANGENT_DIST | CV_CALIB_RATIONAL_MODEL);
+    printf("rms %f with full distortion correction\n", rms);
+
+    cout << distCoeffs << endl;
+
+    projectPoints(world_points[0], rvecs[0], tvecs[0], cameraMatrix, distCoeffs, projected);
+    if (img.channels() == 1)
+        cvtColor(img, paint, CV_GRAY2BGR);
+    else
+        paint = img.clone();
+    //resize(paint, paint, Size(Point2i(paint.size())*4), INTER_LINEAR);
+    for(uint i=0;i<projected.size();i++) {
+        /*Point2f c = img_points[0][i]*4.0+Point2f(2,2);
+    Point2f d = projected[i] - img_points[0][i];
+    line(paint, c-Point2f(2,0), c+Point2f(2,0), Scalar(0,255,0));
+    line(paint, c-Point2f(0,2), c+Point2f(0,2), Scalar(0,255,0));
+    line(paint, c, c+10*d, Scalar(0,0,255));*/
+
+        Point2f c = img_points[0][i];
+        Point2f d = img_points[0][i]-projected[i];
+        line(paint, c-Point2f(2,0), c+Point2f(2,0), Scalar(0,255,0));
+        line(paint, c-Point2f(0,2), c+Point2f(0,2), Scalar(0,255,0));
+        line(paint, c, c+10*d, Scalar(0,0,255));
+    }
+
+    imwrite("off_hdm.jpg", paint);
+}
+
+void check_calibration(vector<Corner> &corners, int w, int h, Mat &img, vector<Corner> &corners_filtered)
+{
+    vector<Mat> rvecs, tvecs;
+    Mat cameraMatrix(3,3,cv::DataType<double>::type);
+    Mat distCoeffs;
+    vector<Point2f> projected;
+    Mat paint;
+
+    vector<vector<Point3f>> world_points(1);
+    vector<vector<Point2f>> img_points[4];
+
+    img_points[0].resize(1);
+    if (use_rgb)
+        for(int c=1;c<4;c++)
+            img_points[c].resize(1);
+
+    printf("corners: %lu\n", corners.size());
+
+    if (!calib_savepoints(img_points, world_points, corners, grid_width, grid_height, corners_filtered)) {
+        return;
+    }
+
+    calibrate_channel(img_points[0], world_points, w, h, img);
+    if (use_rgb)
+        for(int c=1;c<4;c++)
+            calibrate_channel(img_points[c], world_points, w, h, img);
+
+
+    /*cornerSubPix(img, img_points[0], Size(4,4), Size(-1, -1), TermCriteria(TermCriteria::COUNT | TermCriteria::EPS, 100, 0.001));
+
+  distCoeffs = Mat::zeros(1, 8, CV_64F);
+  rms = calibrateCamera(world_points, img_points, Size(w, h), cameraMatrix, distCoeffs, rvecs, tvecs, CV_CALIB_RATIONAL_MODEL);
+  printf("rms %f with full distortion correction, opencv cornerSubPix\n", rms);
+
+  projectPoints(world_points[0], rvecs[0], tvecs[0], cameraMatrix, distCoeffs, projected);
+  cvtColor(img, paint, CV_GRAY2BGR);
+  for(int i=0;i<projected.size();i++) {
+    Point2f d = projected[i] - img_points[0][i];
+    line(paint, img_points[0][i], img_points[0][i]+100*d, Scalar(0,0,255));
+  }
+  imwrite("off_ocv.png", paint);*/
+}
+
+void corrupt(Mat &img)
+{
+    GaussianBlur(img, img, Size(9,9), 0);
+    Mat noise = Mat(img.size(), CV_32F);
+    img. convertTo(img, CV_32F);
+    randn(noise, 0, 3.0);
+    img += noise;
+    img.convertTo(img, CV_8U);
+    cvtColor(img, img, COLOR_BayerBG2BGR_VNG);
+    cvtColor(img, img, CV_BGR2GRAY);
+}
+
+vector<Corner> getCorners(
+        const std::string input_file,
+        const float effort,
+        const bool demosaic,
+        const int recursion_depth
+        ) {
+    std::string pointcache_file = input_file + "-pointcache.yaml";
+    vector<Corner> corners;
+    bool read_cache_success = false;
+
+
+
+    try {
+        if (fs::exists(pointcache_file)) {
+            read_cache_success = true;
+            FileStorage pointcache(pointcache_file, FileStorage::READ);
+            FileNode n = pointcache["corners"]; // Read string sequence - Get node
+            if (n.type() != FileNode::SEQ)
+            {
+                cerr << "corners is not a sequence! FAIL" << endl;
+                read_cache_success = false;
+            }
+
+            FileNodeIterator it = n.begin(), it_end = n.end(); // Go through the node
+            for (; it != it_end; ++it) {
+                hdmarker::Corner c;
+                *it >> c;
+                corners.push_back(c);
+            }
+
+        }
+    }
+    catch (const Exception& e) {
+        std::cout << "Reading pointcache file failed with exception: " << std::endl
+                  << e.what() << std::endl;
+        read_cache_success = false;
+    }
+
+    if (read_cache_success) {
+        std::cout << "Got corners from pointcache file" << std::endl;
+        return corners;
+    }
+
+
+
+
+    //  microbench_init();
+    char buf[64];
+    Mat img, paint;
+    Point2f p1, p2;
+    int x1, y1, x2, y2;
+
+    Corner c;
+
+    if (demosaic) {
+        img = cv::imread(input_file, CV_LOAD_IMAGE_GRAYSCALE);
+        cvtColor(img, img, COLOR_BayerBG2BGR);
+        paint = img.clone();
+    }
+    else {
+        img = cv::imread(input_file);
+        paint = img.clone();
+    }
+    std::cout << "Input image size: " << img.size << std::endl;
+
+    //corrupt(img);
+    //imwrite("corrupted.png", img);
+    Marker::init();
+
+    //  microbench_measure_output("app startup");
+
+    //CALLGRIND_START_INSTRUMENTATION;
+    detect(img, corners,use_rgb,0,10, effort, 3);
+    //CALLGRIND_STOP_INSTRUMENTATION;
+
+    //  microbench_init();
+
+    printf("final score %zu corners\n", corners.size());
+
+    for(size_t i=0;i<corners.size();i++) {
+        c = corners[i];
+        //if (c.page != 256) continue;
+        sprintf(buf, "%d/%d", c.id.x, c.id.y);
+        circle(paint, c.p, 1, Scalar(0,0,0,0), 2);
+        circle(paint, c.p, 1, Scalar(0,255,0,0));
+        putText(paint, buf, c.p, FONT_HERSHEY_PLAIN, 0.5, Scalar(0,0,0,0), 2, CV_AA);
+        putText(paint, buf, c.p, FONT_HERSHEY_PLAIN, 0.5, Scalar(255,255,255,0), 1, CV_AA);
+    }
+    imwrite(input_file + "-1.png", paint);
+
+    //
+    Mat gray;
+    if (img.channels() != 1)
+        cvtColor(img, gray, CV_BGR2GRAY);
+    else
+        gray = img;
+
+    if (recursion_depth > 0) {
+        std::cout << "Drawing sub-markers" << std::endl;
+        vector<Corner> corners_sub;
+        double msize = 1.0;
+        refine_recursive(gray, corners, corners_sub, 3, &msize);
+
+        vector<Corner> corners_f2;
+        check_calibration(corners_sub, img.size().width, img.size().height, img, corners_f2);
+
+        cv::Mat paint2 = paint.clone();
+        for (hdmarker::Corner const& c : corners_f2) {
+            circle(paint2, c.p, 3, Scalar(0,0,255,0), -1, LINE_AA);
+        }
+        imwrite(input_file + "-2.png", paint2);
+    }
+
+    FileStorage pointcache(pointcache_file, FileStorage::WRITE);
+    pointcache << "corners" << "[";
+    for (hdmarker::Corner const& c : corners) {
+        pointcache << c;
+    }
+    pointcache << "]";
+
+    return corners;
+
+}
+
+int main(int argc, char* argv[])
+{
+
+    FileStorage pointcache("testcache", FileStorage::WRITE);
+
+    hdmarker::Corner p(Point(1,2), Point(3,4), 5);
+    pointcache << "corner" << "[" << p << "]";
+
+    pointcache.release();
+
+    pointcache.open("testcache", FileStorage::READ);
+
+    hdmarker::Corner q;
+
+    FileNode fn = pointcache["corner"];
+    int id=0;
+    for (FileNodeIterator it = fn.begin(); it != fn.end(); it++,id++) {
+        *it >> q;
+        std::cout << q.p;
+    }
+
+
+    std::vector<std::string> input_files;
+    int recursion_depth = -1;
+    float effort = 0.5;
+    bool demosaic = false;
+    try {
+        TCLAP::CmdLine cmd("hdmarker calibration tool", ' ', "0.1");
+
+        TCLAP::ValueArg<int> recursive_depth_arg("r", "recursion",
+                                                 "Recursion depth of the sub-marker detection. Set this to the actual recursion depth of the used target.",
+                                                 false, -1, "int");
+        cmd.add(recursive_depth_arg);
+
+        TCLAP::ValueArg<float> effort_arg("e", "effort",
+                                          "Effort value for the marker detection.",
+                                          false, .5, "float");
+        cmd.add(effort_arg);
+
+        TCLAP::SwitchArg demosaic_arg("d", "demosaic",
+                                      "Use this flag if the input images are raw images and demosaicing should be used.",
+                                      false);
+
+        TCLAP::UnlabeledMultiArg<string> input_img_arg("input", "Input images, should contain markers", true, "string");
+        cmd.add(input_img_arg);
+
+
+        cmd.parse(argc, argv);
+
+
+        input_files = input_img_arg.getValue();
+        recursion_depth = recursive_depth_arg.getValue();
+        effort = effort_arg.getValue();
+        demosaic = demosaic_arg.getValue();
+
+        std::cout << "Parameters: " << std::endl
+                  << "Number of input files: " << input_files.size() << std::endl
+                  << "recursion depth: " << recursion_depth << std::endl
+                  << "effort: " << effort << std::endl
+                  << "demosaic: " << (demosaic ? "true" : "false") << std::endl;
+    }
+    catch (TCLAP::ArgException const & e) {
+        std::cerr << e.what() << std::endl;
+        return 0;
+    }
+    catch (...) {
+        std::cerr << "Unknown exception" << std::endl;
+        return 0;
+    }
+
+    std::map<std::string, std::vector<hdmarker::Corner> > detected_markers;
+
+    for (std::string const& input_file : input_files) {
+        detected_markers[input_file] = getCorners(input_file, effort, demosaic, recursion_depth);
+    }
+
+
+    //  microbench_measure_output("app finish");
+    return EXIT_SUCCESS;
+}

--- a/demo/simplecalib.cpp
+++ b/demo/simplecalib.cpp
@@ -1,0 +1,6 @@
+#include "simplecalib.h"
+
+SimpleCalib::SimpleCalib()
+{
+
+}

--- a/demo/simplecalib.h
+++ b/demo/simplecalib.h
@@ -1,0 +1,11 @@
+#ifndef SIMPLECALIB_H
+#define SIMPLECALIB_H
+
+
+class SimpleCalib
+{
+public:
+    SimpleCalib();
+};
+
+#endif // SIMPLECALIB_H

--- a/src/bin/marker_gen.cpp
+++ b/src/bin/marker_gen.cpp
@@ -109,6 +109,15 @@ void checker_add_recursive(Mat &img, Mat &checker)
 
 int main(int argc, char* argv[])
 {
+  if (argc != 4 && argc != 6) {
+    std::cerr << "Usage:" << std::endl
+              << "4-parameter mode: " << (argc > 0 ? argv[0] : "program_name")
+              << " <page nr.> <number of recursive markers> <output image filename>"
+              << std::endl
+              << "6-parameter mode: " << (argc > 0 ? argv[0] : "program_name")
+              << " <page nr.> <number of recursive markers> <width> <height> <output image filename>" << std::endl << std::endl;
+    return EXIT_FAILURE;
+  }
   int page = atoi(argv[1]); 
   
   if (argc == 4) {

--- a/src/lib/hdmarker.cpp
+++ b/src/lib/hdmarker.cpp
@@ -4724,4 +4724,17 @@ void Marker::init(void)
         }
 }
 
+void write(cv::FileStorage& fs, const std::string&, const Corner& x) {
+  x.write(fs);
+}
+
+void read(const cv::FileNode& node, Corner& x, const Corner& default_value) {
+  if(node.empty()) {
+    x = default_value;
+  }
+  else {
+    x.read(node);
+  }
+}
+
 } //namespace hdmarker

--- a/src/lib/hdmarker.hpp
+++ b/src/lib/hdmarker.hpp
@@ -123,10 +123,34 @@ public :
   
   void paint(cv::Mat &img);
   void paint_text(cv::Mat &paint);
+
+
+  void write(cv::FileStorage& fs) const                        //Write serialization for this class
+  {
+      fs << "{"
+         << "p" << p
+         << "pc0" << pc[0]
+         << "pc1" << pc[1]
+         << "pc2" << pc[2]
+         << "id" << id
+         << "page" << page
+         << "size" << size
+         << "}";
+  }
+  void read(const cv::FileNode& node)                          //Read serialization for this class
+  {
+      node["p"] >> p;
+      node["pc0"] >> pc[0];
+      node["pc1"] >> pc[1];
+      node["pc2"] >> pc[2];
+      page = (int)node["page"];
+      size = (float)node["page"];
+  }
 };
 
+void write(cv::FileStorage& fs, const std::string&, const Corner& x);
 
-
+void read(const cv::FileNode& node, Corner& x, const Corner& default_value = Corner());
 
 /**
 * @class Marker

--- a/src/lib/hdmarker.hpp
+++ b/src/lib/hdmarker.hpp
@@ -143,8 +143,9 @@ public :
       node["pc0"] >> pc[0];
       node["pc1"] >> pc[1];
       node["pc2"] >> pc[2];
+      node["id"] >> id;
       page = (int)node["page"];
-      size = (float)node["page"];
+      size = (float)node["size"];
   }
 };
 

--- a/src/lib/subpattern.hpp
+++ b/src/lib/subpattern.hpp
@@ -68,15 +68,16 @@ The \a paint parameter optionally points to a matrix which will be used to draw 
 The \a page parameter allows to select which page id is valid for refinement - This can improve the robustness, but is not generally needed.
 
 */
-void refine_recursive(cv::Mat &img, 
-                      std::vector<Corner> corners, 
-                      std::vector<Corner> &corners_out, 
-                      int depth, double *size, 
-                      cv::Mat *paint = NULL, 
-                      bool *mask_2x2 = NULL, 
-                      int page = -1, 
-                      const std::vector<cv::Rect> &limits = std::vector<cv::Rect>(), 
-                      int flags = KEEP_ALL_LEVELS);
+void refine_recursive(
+        const cv::Mat &img,
+        std::vector<Corner> corners,
+        std::vector<Corner> &corners_out,
+        int depth, double *size,
+        cv::Mat *paint = NULL,
+        bool *mask_2x2 = NULL,
+        int page = -1,
+        const std::vector<cv::Rect> &limits = std::vector<cv::Rect>(),
+        int flags = KEEP_ALL_LEVELS);
 
 
 void hdmarker_subpattern_set_gt_mats(cv::Mat &c, cv::Mat &r, cv::Mat &t);

--- a/src/tests.cpp
+++ b/src/tests.cpp
@@ -1,0 +1,96 @@
+#include <iostream>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+#include <opencv2/opencv.hpp>
+#include <opencv2/imgproc/types_c.h>
+#include <algorithm>
+#include <random>
+
+#include "hdmarker.hpp"
+
+std::random_device rd;
+std::default_random_engine engine(rd());
+std::normal_distribution<double> dist;
+
+cv::Point2d randomPoint() {
+    return cv::Point2d(dist(engine), dist(engine));
+}
+
+bool float_eq(float const a, float const b) {
+    if (std::isnan(a) || std::isnan(b) || std::isinf(a) || std::isinf(b)) {
+        return false;
+    }
+    if (0 == a || 0 == b) {
+        if (std::abs(a-b) < std::numeric_limits<float>::epsilon()) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    }
+    if (std::abs(a-b) / (std::abs(a) + std::abs(b)) < std::numeric_limits<float>::epsilon()) {
+        return true;
+    }
+    return false;
+}
+
+bool point2f_eq(cv::Point2f const& a, cv::Point2f const& b) {
+    return float_eq(a.x, b.x) && float_eq(a.y, b.y);
+}
+
+bool point2i_eq(cv::Point2i const& a, cv::Point2i const& b) {
+    return a.x == b.x && a.y == b.y;
+}
+
+::testing::AssertionResult CornersEqual(hdmarker::Corner const& a, hdmarker::Corner const& b) {
+    if (!point2f_eq(a.p, b.p)) {
+        return ::testing::AssertionFailure() << "at p: " << a.p << " not equal to " << b.p;
+    }
+    for (size_t ii = 0; ii < 3; ++ii) {
+        if (!point2f_eq(a.pc[ii], b.pc[ii])) {
+            return ::testing::AssertionFailure() << "at pc[" << ii << "]: " << a.pc[ii] << " not equal to " << b.pc[ii];
+        }
+    }
+    if (!point2i_eq(a.id, b.id)) {
+        return ::testing::AssertionFailure() << "at id: " << a.id << " not equal to " << b.id;
+    }
+    if (a.page != b.page) {
+        return ::testing::AssertionFailure() << "at page: " << a.page << " not equal to " << b.page;
+    }
+    if (!float_eq(a.size, b.size)) {
+        return ::testing::AssertionFailure() << "at size: " << a.size << "not equal to " << b.size;
+    }
+    return ::testing::AssertionSuccess();
+}
+
+TEST(Corner, opencv_storage) {
+    hdmarker::Corner a, b;
+    a.p = cv::Point2f(1,2);
+    a.id = cv::Point2i(3,4);
+    a.pc[0] = cv::Point2f(5,6);
+    a.pc[1] = cv::Point2f(7,8);
+    a.pc[2] = cv::Point2f(9,10);
+    a.page = 11;
+    a.size = 12;
+    std::string const storage_file = "asdfghjk-test-temp-storage.yaml";
+
+    {
+        cv::FileStorage pointcache(storage_file, cv::FileStorage::WRITE);
+        pointcache << "a" << a;
+        pointcache.release();
+    }
+    {
+        cv::FileStorage pointcache(storage_file, cv::FileStorage::READ);
+        pointcache["a"] >> b;
+    }
+    EXPECT_TRUE(CornersEqual(a,b));
+}
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    std::cout << "RUN_ALL_TESTS return value: " << RUN_ALL_TESTS() << std::endl;
+
+}


### PR DESCRIPTION
The demo tool failed all my captured images since it detected sub-markers too close to existing sub-markers and died with an exception. I changed the code to ignore that error and simply not add the new point.

I tried to find the smallest image reproducing the problem and made this set of images (the ones with 3x3 markers don't reproduce the issue):

![capture000002-sub2](https://user-images.githubusercontent.com/31710/53099393-fad78080-3525-11e9-90c9-a3f77a7a4ffc.png)
![capture000002-sub3](https://user-images.githubusercontent.com/31710/53099403-0165f800-3526-11e9-860c-be663189d558.png)
![capture000002-sub4](https://user-images.githubusercontent.com/31710/53099411-04f97f00-3526-11e9-8d64-a9f7de79e0fa.png)
![capture000002-sub5](https://user-images.githubusercontent.com/31710/53099420-07f46f80-3526-11e9-8f71-99ec16da381a.png)
![capture000002-sub6](https://user-images.githubusercontent.com/31710/53099427-0a56c980-3526-11e9-9e45-666a4d66d2bf.png)
![capture000002-sub7](https://user-images.githubusercontent.com/31710/53099436-0d51ba00-3526-11e9-846b-ce3dfee56f3e.png)
