### PR TITLE
Remove deprecated ceres setting

### DIFF
--- a/src/lib/subpattern.cpp
+++ b/src/lib/subpattern.cpp
@@ -680,7 +680,6 @@ static double fit_gauss_direct(Mat &img, Point2f size, Point2f &p, double *param
   
   if (pcount >= 1000) {
     options.num_threads = 8;
-    options.num_linear_solver_threads = 8;
   }
   
   ceres::Solver::Summary summary;


### PR DESCRIPTION
The current git version of Ceres does not have that option any more so compilation fails.